### PR TITLE
Update `extendr-api`, and use `ndarray` from extendr

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -5,9 +5,8 @@ version = '0.1.0'
 edition = '2021'
 
 [lib]
-crate-type = [ 'staticlib' ]
+crate-type = ['staticlib']
 name = 'mdl'
 
 [dependencies]
-extendr-api = { version = "0.4", features = ["ndarray"] }
-ndarray = '0.16.1'
+extendr-api = { version = "0.7.1", features = ["ndarray"] }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -1,5 +1,4 @@
 use extendr_api::prelude::*;
-use ndarray::{Array2, s};
 use std::collections::HashMap;
 
 #[extendr]
@@ -37,20 +36,11 @@ fn model_matrix(data: List) -> Result<Robj> {
         result.slice_mut(s![.., col_offset..col_offset+n]).assign(&col);
         col_offset += n;
     }
-
-    // Convert from Array2...
-    // TODO: I think the remainder of this function likely could be simpler.
-    let rarray = RArray::new_matrix(
-        result.nrows(),
-        result.ncols(),
-        |r, c| result[[r, c]]
-    );
-
-    // Convert RArray to Robj
-    let robj: Robj = rarray.into();
+    let nrows = result.nrows();
+    let mut robj: Robj = result.try_into().unwrap();
 
     // Create dimnames list
-    let row_names: Vec<String> = (1..=result.nrows()).map(|i| i.to_string()).collect();
+    let row_names: Vec<String> = (1..=nrows).map(|i| i.to_string()).collect();
     let dimnames = List::from_values(&[row_names, column_names.clone()]);
 
     // Set dimnames attribute


### PR DESCRIPTION
The conversions didn't work, because the version of `ndarray` used in this crate is _different_ than the version of `ndarray` that `extendr-api` is equipped with.

