### PR TITLE
match conventions from `model.matrix()`

### DIFF
--- a/R/mtrx.R
+++ b/R/mtrx.R
@@ -13,10 +13,7 @@
 #'
 #' Compared to `model.matrix()`, `mdl::mtrx()`:
 #'
-#' * Names its intercept `intercept` rather than `(Intercept)`.
 #' * Does not accept formulae with inlined functions (like `-` or `*`).
-#' * Names dummy variables created from characters and factors as `colname_level` rather than `colnamelevel`.
-#' * Names dummy variables create from logicals as `colname` rather than `colnameTRUE`.
 #' * Never drops rows (and thus doesn't accept an `na.action`).
 #' * Assumes that factors levels are encoded as they're intended (i.e. `drop.unused.levels` and `xlev` are not accepted).
 #'

--- a/R/mtrx_compatible.R
+++ b/R/mtrx_compatible.R
@@ -1,7 +1,7 @@
-#' Check if `mtrx()` will give analogous results to `model.matrix()`
+#' Check if `mtrx()` will give matching results to `model.matrix()`
 #'
 #' @description
-#' When the following are true, [mtrx()] returns a matrix that is similar to
+#' When the following are true, [mtrx()] returns a matrix that matches
 #' that returned by [model.matrix()] :
 #'
 #' * There are no non-default factor contrasts.
@@ -27,7 +27,7 @@
 #'   matrix to [model.matrix()], and `FALSE` otherwise.
 #'
 #' @details
-#' In this case, "similar" output means that dummy variables will be encoded
+#' In this case, "matching" output means that dummy variables will be encoded
 #' in the same way, missing values will be handled in the same way (returned
 #' as-is), and that [mtrx()] won't error due to the presence of
 #' unsupported column types.

--- a/README.Rmd
+++ b/README.Rmd
@@ -48,10 +48,7 @@ head(
 
 Compared to `model.matrix()`, `mdl::mtrx()` is sort of a glorified `as.matrix()` data frame method. More specifically:
 
-* Names its intercept `intercept` rather than `(Intercept)`.
 * Does not accept formulae with inlined functions (like `-` or `*`).
-* Names dummy variables created from characters and factors as `colname_level` rather than `colnamelevel`.
-* Names dummy variables create from logicals as `colname` rather than `colnameTRUE`.
 * Never drops rows (and thus doesn't accept an `na.action`).
 * Assumes that factors levels are encoded as they're intended (i.e. `drop.unused.levels` and `xlev` are not accepted).
 

--- a/README.md
+++ b/README.md
@@ -39,24 +39,19 @@ mtcars$cyl <- as.factor(mtcars$cyl)
 head(
   mdl::mtrx(mpg ~ ., mtcars)
 )
-#>   intercept cyl_6 cyl_8 disp  hp drat    wt  qsec vs am gear carb
-#> 1         1     1     0  160 110 3.90 2.620 16.46  0  1    4    4
-#> 2         1     1     0  160 110 3.90 2.875 17.02  0  1    4    4
-#> 3         1     0     0  108  93 3.85 2.320 18.61  1  1    4    1
-#> 4         1     1     0  258 110 3.08 3.215 19.44  1  0    3    1
-#> 5         1     0     1  360 175 3.15 3.440 17.02  0  0    3    2
-#> 6         1     1     0  225 105 2.76 3.460 20.22  1  0    3    1
+#>   (Intercept) cyl6 cyl8 disp  hp drat    wt  qsec vs am gear carb
+#> 1           1    1    0  160 110 3.90 2.620 16.46  0  1    4    4
+#> 2           1    1    0  160 110 3.90 2.875 17.02  0  1    4    4
+#> 3           1    0    0  108  93 3.85 2.320 18.61  1  1    4    1
+#> 4           1    1    0  258 110 3.08 3.215 19.44  1  0    3    1
+#> 5           1    0    1  360 175 3.15 3.440 17.02  0  0    3    2
+#> 6           1    1    0  225 105 2.76 3.460 20.22  1  0    3    1
 ```
 
 Compared to `model.matrix()`, `mdl::mtrx()` is sort of a glorified
 `as.matrix()` data frame method. More specifically:
 
-- Names its intercept `intercept` rather than `(Intercept)`.
 - Does not accept formulae with inlined functions (like `-` or `*`).
-- Names dummy variables created from characters and factors as
-  `colname_level` rather than `colnamelevel`.
-- Names dummy variables create from logicals as `colname` rather than
-  `colnameTRUE`.
 - Never drops rows (and thus doesn’t accept an `na.action`).
 - Assumes that factors levels are encoded as they’re intended
   (i.e. `drop.unused.levels` and `xlev` are not accepted).
@@ -72,8 +67,8 @@ bench::mark(
 #> # A tibble: 2 × 6
 #>   expression                         min   median `itr/sec` mem_alloc `gc/sec`
 #>   <bch:expr>                    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
-#> 1 mdl::mtrx(mpg ~ ., mtcars)      22.6µs   23.9µs    40039.    3.32KB     20.0
-#> 2 model.matrix(mpg ~ ., mtcars)  267.8µs  274.6µs     3581.  494.24KB     34.0
+#> 1 mdl::mtrx(mpg ~ ., mtcars)      23.1µs     26µs    37187.    3.32KB     18.6
+#> 2 model.matrix(mpg ~ ., mtcars)  270.2µs    293µs     3337.  494.24KB     31.9
 ```
 
 The factor of speedup isn’t so drastic for larger datasets and datasets
@@ -94,8 +89,8 @@ bench::mark(
 #> # A tibble: 2 × 6
 #>   expression                             min median `itr/sec` mem_alloc `gc/sec`
 #>   <bch:expr>                           <bch> <bch:>     <dbl> <bch:byt>    <dbl>
-#> 1 mdl::mtrx(mpg ~ ., mtcars[rep(1:32,… 1.36s  1.36s     0.736  803.01MB    0.736
-#> 2 model.matrix(mpg ~ ., mtcars[rep(1:… 2.02s  2.02s     0.494    1.86GB    1.98
+#> 1 mdl::mtrx(mpg ~ ., mtcars[rep(1:32,… 1.43s  1.43s     0.701  803.01MB    0.701
+#> 2 model.matrix(mpg ~ ., mtcars[rep(1:… 2.01s  2.01s     0.497    1.86GB    1.99
 ```
 
 Check out [this

--- a/man/mtrx.Rd
+++ b/man/mtrx.Rd
@@ -22,10 +22,7 @@ like \code{model.matrix()}.
 
 Compared to \code{model.matrix()}, \code{mdl::mtrx()}:
 \itemize{
-\item Names its intercept \code{intercept} rather than \code{(Intercept)}.
 \item Does not accept formulae with inlined functions (like \code{-} or \code{*}).
-\item Names dummy variables created from characters and factors as \code{colname_level} rather than \code{colnamelevel}.
-\item Names dummy variables create from logicals as \code{colname} rather than \code{colnameTRUE}.
 \item Never drops rows (and thus doesn't accept an \code{na.action}).
 \item Assumes that factors levels are encoded as they're intended (i.e. \code{drop.unused.levels} and \code{xlev} are not accepted).
 }

--- a/man/mtrx_compatible.Rd
+++ b/man/mtrx_compatible.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/mtrx_compatible.R
 \name{mtrx_compatible}
 \alias{mtrx_compatible}
-\title{Check if \code{mtrx()} will give analogous results to \code{model.matrix()}}
+\title{Check if \code{mtrx()} will give matching results to \code{model.matrix()}}
 \usage{
 mtrx_compatible(data, na_action = getOption("na.action"))
 }
@@ -17,7 +17,7 @@ A logical value. Returns TRUE if \code{\link[=mtrx]{mtrx()}} will return a simil
 matrix to \code{\link[=model.matrix]{model.matrix()}}, and \code{FALSE} otherwise.
 }
 \description{
-When the following are true, \code{\link[=mtrx]{mtrx()}} returns a matrix that is similar to
+When the following are true, \code{\link[=mtrx]{mtrx()}} returns a matrix that matches
 that returned by \code{\link[=model.matrix]{model.matrix()}} :
 \itemize{
 \item There are no non-default factor contrasts.
@@ -36,7 +36,7 @@ write:
 }\if{html}{\out{</div>}}
 }
 \details{
-In this case, "similar" output means that dummy variables will be encoded
+In this case, "matching" output means that dummy variables will be encoded
 in the same way, missing values will be handled in the same way (returned
 as-is), and that \code{\link[=mtrx]{mtrx()}} won't error due to the presence of
 unsupported column types.

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -14,7 +14,7 @@ fn model_matrix(data: List) -> Result<Robj> {
         }
     });
 
-    // every factor level but the first is turned into a one-hot vector, 
+    // every factor level but the first is turned into a one-hot vector,
     // thus every factor results in levels()-1 many more columns
     let ncol: usize = columns
         .clone()
@@ -132,7 +132,7 @@ fn process_factor_column(
             .unwrap()
             .skip(1)
             // this is a different separator than the one used in `model.matrix` in R
-            .map(|level| format!("{}_{}", col_name, level)),
+            .map(|level| format!("{}{}", col_name, level)),
     );
     // remove the first level from all the factors
     let level_index = column.as_integer_slice().unwrap().iter().map(|x| *x - 2);
@@ -164,7 +164,7 @@ fn process_logical_column(
     output_column_names: &mut Vec<String>,
     output: &mut [f64],
 ) {
-    output_column_names.push(col_name.to_string());
+    output_column_names.push(format!("{}TRUE", col_name));
     zip(column.as_logical_iter().unwrap(), output.iter_mut()).for_each(
         |(logical_element, output)| {
             *output = logical_element.to_bool() as i32 as f64;

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -36,7 +36,7 @@ fn model_matrix(data: List) -> Result<Robj> {
 
     // Add intercept column
     processed_columns[0..nrow].fill(1.);
-    column_names.push("intercept".to_string());
+    column_names.push("(Intercept)".to_string());
 
     // Iterate through columns
     let mut current_column = 1; // we passed the intercept

--- a/tests/testthat/test-mtrx.R
+++ b/tests/testthat/test-mtrx.R
@@ -14,15 +14,8 @@ test_that("mtrx() gives similar results to model.matrix()", {
 
   res_mtrx <- mtrx(outcome ~ ., d)
   res_base <- model.matrix(outcome ~ ., d)
-  dimnames(res_base) <- dimnames(res_mtrx)
 
   expect_equal(res_mtrx, res_base, ignore_attr = TRUE)
-  expect_equal(
-    colnames(res_mtrx),
-    c("intercept", "pred_numeric", "pred_integer", "pred_logical",
-      "pred_factor_2_b", "pred_factor_3_b", "pred_factor_3_c", "pred_character_2_b",
-      "pred_character_3_b", "pred_character_3_c")
-  )
   expect_equal(rownames(res_mtrx), as.character(seq(1, nrow(res_mtrx))))
   expect_equal(nrow(d), nrow(res_mtrx))
 })
@@ -37,7 +30,6 @@ test_that("mtrx() works with missing values", {
   d_numeric <- cbind(d, pred_numeric = c(NA, runif(29)))
   expect_no_condition(res_mtrx <- mtrx(outcome ~ ., d_numeric))
   res_base <- model.matrix(outcome ~ ., d_numeric)
-  dimnames(res_base) <- dimnames(res_mtrx)
   expect_equal(res_mtrx, res_base, ignore_attr = TRUE)
 
   # in integer:
@@ -45,7 +37,6 @@ test_that("mtrx() works with missing values", {
   d_integer$pred_integer[1] <- NA
   expect_no_condition(res_mtrx <- mtrx(outcome ~ ., d_integer))
   res_base <- model.matrix(outcome ~ ., d_integer)
-  dimnames(res_base) <- dimnames(res_mtrx)
   expect_equal(res_mtrx, res_base, ignore_attr = TRUE)
 
   # in factor:
@@ -53,7 +44,6 @@ test_that("mtrx() works with missing values", {
   d_factor$pred_factor[1] <- NA
   expect_no_condition(res_mtrx <- mtrx(outcome ~ ., d_factor))
   res_base <- model.matrix(outcome ~ ., d_factor)
-  dimnames(res_base) <- dimnames(res_mtrx)
   expect_equal(res_mtrx, res_base, ignore_attr = TRUE)
 
   # in character:
@@ -61,7 +51,6 @@ test_that("mtrx() works with missing values", {
   d_character$pred_character[1] <- NA
   expect_no_condition(res_mtrx <- mtrx(outcome ~ ., d_character))
   res_base <- model.matrix(outcome ~ ., d_character)
-  dimnames(res_base) <- dimnames(res_mtrx)
   expect_equal(res_mtrx, res_base, ignore_attr = TRUE)
 
 })


### PR DESCRIPTION
`mtrx()` now uses the same column names as `model.matrix()` so that results can match exactly.